### PR TITLE
[D-0] Alert show 파라미터 변경

### DIFF
--- a/Projects/Shared/DesignSystem/Demo/Sources/ViewControllers/AlertVC.swift
+++ b/Projects/Shared/DesignSystem/Demo/Sources/ViewControllers/AlertVC.swift
@@ -33,21 +33,21 @@ final class AlertVC: UIViewController {
     
     showOkAlertButton.addAction {
       AlertsManager.show(
-        self,
         title: "메인 타이틀1",
         subTitle: nil,
-        okAction: { print("ok") },
-        cancelAction: nil
+        type: .onlyOkButton({ print("ok") })
       )
     }
     
     showCanCancelButton.addAction {
       AlertsManager.show(
-        self,
         title: "메인 타이틀1",
         subTitle: "서브 타이틀2",
-        okAction: { print("ok") },
-        cancelAction: { print("cancel") }
+        type: .default(okAction: {
+          print("ok")
+        }, cancelAction: {
+          print("cancel")
+        })
       )
     }
   }

--- a/Projects/Shared/DesignSystem/Sources/Alerts/AlertsManager.swift
+++ b/Projects/Shared/DesignSystem/Sources/Alerts/AlertsManager.swift
@@ -3,17 +3,14 @@ import UIKit
 public final class AlertsManager {
   /// cancelAction과 subTitle은 값이 nil인 경우 UI 표시 X
   public static func show(
-    _ vc: UIViewController,
     title: String,
-    subTitle: String?,
-    okAction: @escaping () -> Void,
-    cancelAction: (() -> Void)?
+    subTitle: String? = nil,
+    type: MMAlerts.`Type` = .default()
   ) {
     let alert = MMAlerts(
       title: title,
       subTitle: subTitle,
-      okAction: okAction,
-      cancelAction: cancelAction
+      type: type
     )
     
     alert.modalPresentationStyle = .overFullScreen
@@ -24,7 +21,7 @@ public final class AlertsManager {
       .compactMap({ $0 as? UIWindowScene })
       .first?.windows
       .filter({ $0.isKeyWindow }).first?
-      .rootViewController?.topViewController()
+      .rootViewController?.searchTopViewController()
     else {
       return
     }

--- a/Projects/Shared/DesignSystem/Sources/Utils/UIViewController+.swift
+++ b/Projects/Shared/DesignSystem/Sources/Utils/UIViewController+.swift
@@ -56,22 +56,18 @@ public extension UIViewController {
     navigationItem.rightBarButtonItem = item.button
   }
   
-  func topViewController() -> UIViewController {
-    return searchTopViewController(of: self)
-  }
-  
-  private func searchTopViewController(of viewController: UIViewController) -> UIViewController {
-    if let presentedViewController = viewController.presentedViewController {
-      return searchTopViewController(of: presentedViewController)
+  func searchTopViewController() -> UIViewController {
+    if let presentedViewController = self.presentedViewController {
+      return presentedViewController.searchTopViewController()
     }
-    if let navigationViewController = viewController as? UINavigationController,
+    if let navigationViewController = self as? UINavigationController,
        let topViewController = navigationViewController.topViewController {
-      return searchTopViewController(of: topViewController)
+      return topViewController.searchTopViewController()
     }
-    if let tabBarController = viewController as? UITabBarController,
+    if let tabBarController = self as? UITabBarController,
        let selectedViewController = tabBarController.selectedViewController {
-      return searchTopViewController(of: selectedViewController)
+      return selectedViewController.searchTopViewController()
     }
-    return viewController
+    return self
   }
 }


### PR DESCRIPTION
## 작업 내용

- [x] alert enum 타입 구현
- [x] Alert show 파라미터 수정

## 리뷰어에게 (필요시)

Alert show 파라미터가 수정되었습니다.
subTitle 및 액션 클로저의 경우 기본값이 있기 때문에 필요시에만 주입하시면 됩니다.

- 액션이 없는 기본 얼럿을 띄우고 싶을 때 
```swift
AlertsManager.show(
  title: "메인 타이틀1"
)
```
- 액션이 없는 ok 버튼만 있는 얼럿을 띄우고 싶을 때

```swift
AlertsManager.show(
  title: "메인 타이틀1",
  type: .onlyOkButton()
)
```

- 액션이 있는 ok 버튼만 있는 얼럿을 띄우고 싶을 때

```swift
AlertsManager.show(
  title: "메인 타이틀1",
  type: .onlyOkButton(
    {
      // 액션
    }
  )
)
```
- 액션이 있는 기본 얼럿을 띄우고 싶을때
```swift
AlertsManager.show(
  title: "메인 타이틀1",
  subTitle: "서브 타이틀2",
  type: .default(okAction: {
     // ok 액션
  }, cancelAction: {
     // cancel 액션
  }) // 클로저의 경우 주입할 액션이 있는 클로저만 여시면 됩니다.
)
```

## 스크린샷 (필요시)
