### PR TITLE
[D-1] scrollView contentInset를 활용해 키보드 높이 처리 408

### DIFF
--- a/Projects/Feature/Ledger/Sources/Scene/Ledger/Creaters/Manual/ManualCreater/CreateManualLedgerVC.swift
+++ b/Projects/Feature/Ledger/Sources/Scene/Ledger/Creaters/Manual/ManualCreater/CreateManualLedgerVC.swift
@@ -31,6 +31,7 @@ final class CreateManualLedgerVC: BaseVC, View {
   
   private let scrollView: UIScrollView = {
     let v = UIScrollView()
+    v.contentInset.bottom = 100
     v.keyboardDismissMode = .interactive
     return v
   }()
@@ -47,7 +48,6 @@ final class CreateManualLedgerVC: BaseVC, View {
 
     return v
   }()
-  private let keyboardSpaceView = UIView()
   private let recepitImageView: UIImageView = {
     let v = UIImageView()
     v.contentMode = .scaleAspectFill
@@ -230,11 +230,11 @@ final class CreateManualLedgerVC: BaseVC, View {
               flex.addItem(writerTitleLabel).marginBottom(8)
               flex.addItem(writerNameLabel)
             }
+            .marginBottom(25)
           }
-        }.paddingBottom(50)
+        }
       }
       
-      flex.addItem(keyboardSpaceView).backgroundColor(.clear).height(60)
       flex.addItem(smogView).position(.absolute).bottom(0).horizontally(0).height(100)
     }
     view.addSubview(completeButton)
@@ -352,16 +352,12 @@ final class CreateManualLedgerVC: BaseVC, View {
       .bind(with: self) { owner, noti in
         guard let keyboardFrame = noti.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else { return }
         let keyboardHeight = keyboardFrame.cgRectValue.height
-        owner.keyboardSpaceView.flex.height(
-          keyboardHeight - owner.view.safeAreaInsets.bottom
-        ).markDirty()
-        owner.rootContainer.flex.layout()
+        owner.scrollView.contentInset.bottom = keyboardHeight
       }.disposed(by: disposeBag)
     
     NotificationCenter.default.rx.notification(UIResponder.keyboardWillHideNotification)
       .bind(with: self) { owner, _ in
-        owner.keyboardSpaceView.flex.height(60).markDirty()
-        owner.rootContainer.flex.layout()
+        owner.scrollView.contentInset.bottom = 100
       }.disposed(by: disposeBag)
   }
   


### PR DESCRIPTION
## 작업 내용

슬라이드 제스처를 사용하여 키보드를 내릴 시 여백이 생기는 문제를 해결하기 위해
기존 keyboardSpaceView 사용해 키보드 높이만큼 화면을 올려주는 방식에서
scrollView contentInset bottom 값을 변경하는 방식으로 수정

## 리뷰어에게 (필요시)

- ~참고 해주세요

## 스크린샷 (필요시)
|수정 전|수정 후|
|-|-|
|<img src="https://github.com/MONEYMONG/iOS-Moneymong/assets/91936941/5169426f-eecd-4ff7-a913-308503441fc2" width=200>|<img src="https://github.com/MONEYMONG/iOS-Moneymong/assets/91936941/1f9e0d2c-544c-4646-a72f-28ab02bb87f6" width=200>|



