### PR TITLE
[D-1] Network Logger 구현 (539)

### DIFF
--- a/Projects/Core/Core/Sources/Network/APIs/SignAPI/Repository/SignRepository.swift
+++ b/Projects/Core/Core/Sources/Network/APIs/SignAPI/Repository/SignRepository.swift
@@ -22,7 +22,7 @@ public final class SignRepository: SignRepositoryInterface {
   private let appleAuthManager: AppleAuthManager
 
   public init(
-    networkManager: NetworkManagerInterfacae = NetworkManager(),
+    networkManager: NetworkManagerInterfacae,
     localStorage: LocalStorageInterface = LocalStorage(),
     kakaoAuthManager: KakaoAuthManager = .shared,
     appleAuthManager: AppleAuthManager = AppleAuthManager()

--- a/Projects/Core/Core/Sources/Network/APIs/UniversityAPI/Repository/UniversityRepository.swift
+++ b/Projects/Core/Core/Sources/Network/APIs/UniversityAPI/Repository/UniversityRepository.swift
@@ -9,7 +9,7 @@ public protocol UniversityRepositoryInterface {
 public final class UniversityRepository: UniversityRepositoryInterface {
   private let networkManager: NetworkManagerInterfacae
 
-  public init(networkManager: NetworkManagerInterfacae = NetworkManager()) {
+  public init(networkManager: NetworkManagerInterfacae) {
     self.networkManager = networkManager
   }
 

--- a/Projects/Core/Core/Sources/Network/Common/NetworkLogger.swift
+++ b/Projects/Core/Core/Sources/Network/Common/NetworkLogger.swift
@@ -1,0 +1,42 @@
+import Foundation
+import OSLog
+
+import Alamofire
+
+final class NetworkLogger: EventMonitor {
+  let queue = DispatchQueue(label: "NetworkLogger")
+  
+  private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "", category: "NetworkLogger")
+  
+  func request<Value>(_ request: DataRequest, didParseResponse response: DataResponse<Value, AFError>) where Value : Sendable {
+    let statusCode = response.response?.statusCode ?? 0
+    var log = (200..<300) ~= statusCode ? "OK" : "Fail"
+    log.append("  ")
+    
+    log.append(request.description)
+    log.append("\n\n")
+    
+    log.append("------------------- Request --------------------------\n\n")
+
+    log.append("URL: \(request.request?.url?.absoluteString ?? "")\n")
+    log.append("Method: \(request.request?.httpMethod ?? "")\n")
+    log.append("Headers: \(request.request?.allHTTPHeaderFields ?? [:])\n")
+    log.append("Authorization: \(request.request?.headers["Authorization"] ?? "None")\n")
+    log.append("Body: \(request.request?.httpBody?.toPrettyPrintedString ?? "None")\n\n")
+    
+    log.append("------------------- Response --------------------------\n\n")
+    
+    log.append("\(response.data?.toPrettyPrintedString ?? "None")")
+    
+    logger.log("\(log)")
+  }
+}
+
+private extension Data {
+  var toPrettyPrintedString: String? {
+    guard let object = try? JSONSerialization.jsonObject(with: self, options: []),
+          let data = try? JSONSerialization.data(withJSONObject: object, options: [.prettyPrinted]),
+          let prettyPrintedString = NSString(data: data, encoding: String.Encoding.utf8.rawValue) else { return nil }
+    return prettyPrintedString as String
+  }
+}

--- a/Projects/Core/Core/Sources/Network/Common/NetworkManager.swift
+++ b/Projects/Core/Core/Sources/Network/Common/NetworkManager.swift
@@ -12,10 +12,12 @@ public final class NetworkManager: NetworkManagerInterfacae {
   
   public var tokenIntercepter: TokenRequestIntercepter?
   
+  private let session = Session(eventMonitors: [NetworkLogger()])
+  
   public init() {}
   
   public func request(target: TargetType) async throws {
-    let dataResponse = await AF.request(target, interceptor: tokenIntercepter)
+    let dataResponse = await session.request(target, interceptor: tokenIntercepter)
       .validateTokenExpire()
       .serializingData()
       .response
@@ -56,7 +58,7 @@ public final class NetworkManager: NetworkManagerInterfacae {
     let dataRequest: DataRequest
     switch target.task {
     case .upload(let multipartFormData):
-      dataRequest = AF.upload(
+      dataRequest = session.upload(
         multipartFormData: multipartFormData,
         with: target,
         interceptor: tokenIntercepter
@@ -64,7 +66,7 @@ public final class NetworkManager: NetworkManagerInterfacae {
       .validateTokenExpire()
       
     default:
-      dataRequest = AF.request(
+      dataRequest = session.request(
         target,
         interceptor: tokenIntercepter
       )

--- a/Projects/Feature/Sign/Sources/Scene/Common/SignDIContainer.swift
+++ b/Projects/Feature/Sign/Sources/Scene/Common/SignDIContainer.swift
@@ -6,7 +6,7 @@ public final class SignDIContainer {
 
   public init(
     localStorage: LocalStorageInterface = LocalStorage(),
-    networkManager: NetworkManagerInterfacae = NetworkManager()
+    networkManager: NetworkManagerInterfacae
   ) {
     self.localStorage = localStorage
     self.networkManager = networkManager


### PR DESCRIPTION
## 작업 내용

- [x] Network logger 구현

## 리뷰어에게 (필요시)

pulse 대신 네트워크 요청에 따라 log를 확인할 수 있도록 구현했습니다.

콘솔에서 네트워크 요청에 따른 결과와 리스폰스를 확인할 수 있습니다.

## 스크린샷 (필요시)

![image](https://github.com/user-attachments/assets/39604f4a-016e-40bb-a7d0-23ae034e6963)

