### PR TITLE
[D-0] hotfix capture Session 백그라운드 스레드에서 동작하도록 수정

### DIFF
--- a/Projects/Feature/Ledger/Sources/Scene/Ledger/Creaters/Scan/Components/CameraView.swift
+++ b/Projects/Feature/Ledger/Sources/Scene/Ledger/Creaters/Scan/Components/CameraView.swift
@@ -77,7 +77,7 @@ final class CameraView: UIView {
     try configureCameraFocus(backCamera)
     
     // 세션 시작
-    DispatchQueue.main.async {
+    DispatchQueue.global().async {
       self.captureSession.startRunning()
     }
   }
@@ -108,6 +108,3 @@ final class CameraView: UIView {
     }
   }
 }
-
-
-


### PR DESCRIPTION
## 작업 내용

- [x] capture Session 백그라운드 스레드에서 동작하도록 수정

## 리뷰어에게 (필요시)

<img width="948" alt="스크린샷 2024-12-24 오전 11 56 52" src="https://github.com/user-attachments/assets/71bc29d7-3cd7-4a35-88cb-14c23f8c5f2b" />

위 이미지와 같이 `startRunning()` 메서드가 main 스레드에서 호출 시 동작하지 않을 수 있다는 경고가 표시되어 백그라운드 스레드에서 동작하도록 수정하였습니다.

## 스크린샷 (필요시)
