### PR TITLE
[D-0] Vision를 통해 영수증 스캔 기능 구현

### DIFF
--- a/Projects/Feature/Ledger/Sources/Scene/Ledger/Creaters/Scan/Components/CameraView.swift
+++ b/Projects/Feature/Ledger/Sources/Scene/Ledger/Creaters/Scan/Components/CameraView.swift
@@ -170,5 +170,3 @@ extension CameraView: AVCapturePhotoCaptureDelegate {
     }
   }
 }
-
-extension CVImageBuffer: @unchecked @retroactive Sendable {}

--- a/Projects/Feature/Ledger/Sources/Scene/Ledger/Creaters/Scan/Components/CameraView.swift
+++ b/Projects/Feature/Ledger/Sources/Scene/Ledger/Creaters/Scan/Components/CameraView.swift
@@ -5,8 +5,21 @@ import Core
 
 import RxSwift
 
+protocol CameraViewDelegate: AnyObject {
+  func cameraView(_ cameraView: CameraView, didShot result: UIImage)
+}
+
 final class CameraView: UIView {
-  weak var delegate: AVCapturePhotoCaptureDelegate?
+  weak var delegate: CameraViewDelegate?
+  
+  private var scanFailedCount = 0 {
+    didSet {
+      if scanFailedCount > 10, !maskLayer.isHidden {
+        maskLayer.isHidden = true
+        scanFailedCount = 0
+      }
+    }
+  }
   
   private let captureSession: AVCaptureSession = {
     let session = AVCaptureSession()
@@ -15,6 +28,10 @@ final class CameraView: UIView {
   }()
   
   private let stillImageOutput = AVCapturePhotoOutput()
+  private let videoDataOutput = AVCaptureVideoDataOutput()
+  private let documentScanner = DocumentScanner()
+  
+  private var maskLayer = CAShapeLayer()
   
   private let videoPreviewLayer: AVCaptureVideoPreviewLayer = {
     let layer = AVCaptureVideoPreviewLayer()
@@ -70,6 +87,18 @@ final class CameraView: UIView {
       captureSession.addOutput(stillImageOutput)
     }
     
+    if captureSession.canAddOutput(videoDataOutput) {
+      self.videoDataOutput.setSampleBufferDelegate(self, queue: .global())
+      captureSession.addOutput(videoDataOutput)
+      
+      guard let connection = self.videoDataOutput.connection(with: AVMediaType.video),
+            connection.isVideoOrientationSupported else { return }
+      
+      connection.videoOrientation = .portrait
+    }
+    
+    self.layer.addSublayer(maskLayer)
+    
     // 프리뷰 레이어 설정
     videoPreviewLayer.session = captureSession
     
@@ -100,11 +129,45 @@ final class CameraView: UIView {
   
   var takePhoto: Binder<Void> {
     return Binder(self) { owner, _ in
-      guard let delegate = owner.delegate else {
-        fatalError("델리게이트를 설정하세요.")
-      }
       let settings = AVCapturePhotoSettings()
-      owner.stillImageOutput.capturePhoto(with: settings, delegate: delegate)
+      owner.stillImageOutput.capturePhoto(with: settings, delegate: owner)
     }
   }
 }
+
+extension CameraView: AVCaptureVideoDataOutputSampleBufferDelegate {
+  func captureOutput(_ output: AVCaptureOutput,didOutput sampleBuffer: CMSampleBuffer,from connection: AVCaptureConnection) {
+    guard let buffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return }
+
+    Task {
+      guard let scanRect = try await documentScanner.scanDocument(previewSize: self.bounds, pixelBuffer: buffer) else {
+        scanFailedCount += 1
+        return
+      }
+      scanFailedCount = 0
+      updateMaskLayer(in: scanRect)
+    }
+  }
+  
+  private func updateMaskLayer(in rect: CGRect) {
+    maskLayer.isHidden = false
+    maskLayer.frame = rect
+    maskLayer.cornerRadius = 10
+    maskLayer.borderColor = UIColor.systemBlue.cgColor
+    maskLayer.borderWidth = 1
+    maskLayer.opacity = 1
+  }
+}
+
+extension CameraView: AVCapturePhotoCaptureDelegate {
+  func photoOutput(_ output: AVCapturePhotoOutput, didFinishProcessingPhoto photo: AVCapturePhoto, error: Error?) {
+    Task {
+      guard let imageData = photo.fileDataRepresentation(),
+            let result = await documentScanner.editImageWithScanResult(imageData) else { return }
+      
+      delegate?.cameraView(self, didShot: UIImage(cgImage: result))
+    }
+  }
+}
+
+extension CVImageBuffer: @unchecked @retroactive Sendable {}

--- a/Projects/Feature/Ledger/Sources/Scene/Ledger/Creaters/Scan/Components/CameraView.swift
+++ b/Projects/Feature/Ledger/Sources/Scene/Ledger/Creaters/Scan/Components/CameraView.swift
@@ -166,7 +166,7 @@ extension CameraView: AVCapturePhotoCaptureDelegate {
             let originalImage = UIImage(data: imageData),
             let result = await documentScanner.editImageWithScanResult(imageData) else { return }
       
-      delegate?.cameraView(self, scanResult: UIImage(cgImage: result), originalImage: originalImage)
+      delegate?.cameraView(self, scanResult: UIImage(ciImage: result), originalImage: originalImage)
     }
   }
 }

--- a/Projects/Feature/Ledger/Sources/Scene/Ledger/Creaters/Scan/Components/CameraView.swift
+++ b/Projects/Feature/Ledger/Sources/Scene/Ledger/Creaters/Scan/Components/CameraView.swift
@@ -6,7 +6,7 @@ import Core
 import RxSwift
 
 protocol CameraViewDelegate: AnyObject {
-  func cameraView(_ cameraView: CameraView, didShot result: UIImage)
+  func cameraView(_ cameraView: CameraView, scanResult result: UIImage, originalImage image: UIImage)
 }
 
 final class CameraView: UIView {
@@ -163,9 +163,10 @@ extension CameraView: AVCapturePhotoCaptureDelegate {
   func photoOutput(_ output: AVCapturePhotoOutput, didFinishProcessingPhoto photo: AVCapturePhoto, error: Error?) {
     Task {
       guard let imageData = photo.fileDataRepresentation(),
+            let originalImage = UIImage(data: imageData),
             let result = await documentScanner.editImageWithScanResult(imageData) else { return }
       
-      delegate?.cameraView(self, didShot: UIImage(cgImage: result))
+      delegate?.cameraView(self, scanResult: UIImage(cgImage: result), originalImage: originalImage)
     }
   }
 }

--- a/Projects/Feature/Ledger/Sources/Scene/Ledger/Creaters/Scan/Components/CameraView.swift
+++ b/Projects/Feature/Ledger/Sources/Scene/Ledger/Creaters/Scan/Components/CameraView.swift
@@ -140,7 +140,7 @@ extension CameraView: AVCaptureVideoDataOutputSampleBufferDelegate {
     guard let buffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return }
 
     Task {
-      guard let scanRect = try await documentScanner.scanDocument(previewSize: self.bounds, pixelBuffer: buffer) else {
+      guard let scanRect = try await documentScanner.scanDocument(imageBuffer: buffer, with: bounds) else {
         scanFailedCount += 1
         return
       }

--- a/Projects/Feature/Ledger/Sources/Scene/Ledger/Creaters/Scan/Model/DocumentScanner.swift
+++ b/Projects/Feature/Ledger/Sources/Scene/Ledger/Creaters/Scan/Model/DocumentScanner.swift
@@ -35,8 +35,8 @@ actor DocumentScanner: Sendable {
     }
   }
   
-  func editImageWithScanResult(_ imageData: Data) -> CGImage? {
-    guard var ciImage = CIImage(data: imageData)?.oriented(.right),
+  func editImageWithScanResult(_ imageData: Data) -> CIImage? {
+    guard let ciImage = CIImage(data: imageData)?.oriented(.right),
           let recentScanResult else { return nil }
     
     let topLeft = recentScanResult.topLeft.scaled(to: ciImage.extent.size)
@@ -44,15 +44,12 @@ actor DocumentScanner: Sendable {
     let bottomLeft = recentScanResult.bottomLeft.scaled(to: ciImage.extent.size)
     let bottomRight = recentScanResult.bottomRight.scaled(to: ciImage.extent.size)
 
-    ciImage = ciImage.applyingFilter("CIPerspectiveCorrection", parameters: [
+    return ciImage.applyingFilter("CIPerspectiveCorrection", parameters: [
       "inputTopLeft": CIVector(cgPoint: topLeft),
       "inputTopRight": CIVector(cgPoint: topRight),
       "inputBottomLeft": CIVector(cgPoint: bottomLeft),
       "inputBottomRight": CIVector(cgPoint: bottomRight),
     ])
-
-    let context = CIContext()
-    return context.createCGImage(ciImage, from: ciImage.extent)
   }
   
   private func transformVisionToIOS(_ rectangleObservation: VNRectangleObservation, to previewSize: CGRect) -> CGRect {

--- a/Projects/Feature/Ledger/Sources/Scene/Ledger/Creaters/Scan/Model/DocumentScanner.swift
+++ b/Projects/Feature/Ledger/Sources/Scene/Ledger/Creaters/Scan/Model/DocumentScanner.swift
@@ -1,0 +1,48 @@
+import Vision
+
+actor DocumentScanner: Sendable {
+  private var recentScanResult: VNRectangleObservation?
+  
+  func scanDocument(previewSize: CGRect, pixelBuffer: CVPixelBuffer) async throws -> CGRect? {
+    return try await withCheckedThrowingContinuation { [weak self] continuation in
+      guard let self else { continuation.resume(returning: nil); return }
+      let request = VNDetectRectanglesRequest { (request: VNRequest, error: Error?) in
+        guard let results = request.results as? [VNRectangleObservation],
+              let rectangleObservation = results.first else {
+          continuation.resume(returning: nil); return
+        }
+        
+        Task {
+          await self.updateRecentScanResult(rectangleObservation)
+          let rect = await self.transformBoundingBox(rectangleObservation, to: previewSize)
+          continuation.resume(returning: rect)
+        }
+      }
+      
+      request.minimumAspectRatio = 0.3
+      request.maximumAspectRatio = 0.9
+      request.minimumSize = 0.3
+      request.maximumObservations = 1
+      request.minimumConfidence = 0.8
+      
+      let handler = VNImageRequestHandler(cvPixelBuffer: pixelBuffer, options: [:])
+      do {
+        try handler.perform([request])
+      } catch {
+        continuation.resume(throwing: error)
+      }
+    }
+  }
+  
+  private func transformBoundingBox(_ rectangleObservation: VNRectangleObservation, to previewSize: CGRect) -> CGRect {
+    let transform = CGAffineTransform(scaleX: 1, y: -1).translatedBy(x: 0, y: -previewSize.height)
+    let scale = CGAffineTransform.identity.scaledBy(x: previewSize.width, y: previewSize.height)
+
+    return rectangleObservation.boundingBox.applying(scale).applying(transform)
+  }
+  
+  private func updateRecentScanResult(_ rectangleObservation: VNRectangleObservation) {
+    recentScanResult = rectangleObservation
+  }
+}
+

--- a/Projects/Feature/Ledger/Sources/Scene/Ledger/Creaters/Scan/Model/DocumentScanner.swift
+++ b/Projects/Feature/Ledger/Sources/Scene/Ledger/Creaters/Scan/Model/DocumentScanner.swift
@@ -1,4 +1,5 @@
 import Vision
+import CoreImage
 
 actor DocumentScanner: Sendable {
   private var recentScanResult: VNRectangleObservation?
@@ -34,6 +35,26 @@ actor DocumentScanner: Sendable {
     }
   }
   
+  func editImageWithScanResult(_ imageData: Data) -> CGImage? {
+    guard var ciImage = CIImage(data: imageData)?.oriented(.right),
+          let recentScanResult else { return nil }
+    
+    let topLeft = recentScanResult.topLeft.scaled(to: ciImage.extent.size)
+    let topRight = recentScanResult.topRight.scaled(to: ciImage.extent.size)
+    let bottomLeft = recentScanResult.bottomLeft.scaled(to: ciImage.extent.size)
+    let bottomRight = recentScanResult.bottomRight.scaled(to: ciImage.extent.size)
+
+    ciImage = ciImage.applyingFilter("CIPerspectiveCorrection", parameters: [
+      "inputTopLeft": CIVector(cgPoint: topLeft),
+      "inputTopRight": CIVector(cgPoint: topRight),
+      "inputBottomLeft": CIVector(cgPoint: bottomLeft),
+      "inputBottomRight": CIVector(cgPoint: bottomRight),
+    ])
+
+    let context = CIContext()
+    return context.createCGImage(ciImage, from: ciImage.extent)
+  }
+  
   private func transformBoundingBox(_ rectangleObservation: VNRectangleObservation, to previewSize: CGRect) -> CGRect {
     let transform = CGAffineTransform(scaleX: 1, y: -1).translatedBy(x: 0, y: -previewSize.height)
     let scale = CGAffineTransform.identity.scaledBy(x: previewSize.width, y: previewSize.height)
@@ -43,6 +64,13 @@ actor DocumentScanner: Sendable {
   
   private func updateRecentScanResult(_ rectangleObservation: VNRectangleObservation) {
     recentScanResult = rectangleObservation
+  }
+}
+
+private extension CGPoint {
+  func scaled(to size: CGSize) -> CGPoint {
+    return CGPoint(x: self.x * size.width,
+                   y: self.y * size.height)
   }
 }
 

--- a/Projects/Feature/Ledger/Sources/Scene/Ledger/Creaters/Scan/Model/DocumentScanner.swift
+++ b/Projects/Feature/Ledger/Sources/Scene/Ledger/Creaters/Scan/Model/DocumentScanner.swift
@@ -4,7 +4,7 @@ import CoreImage
 actor DocumentScanner: Sendable {
   private var recentScanResult: VNRectangleObservation?
   
-  func scanDocument(previewSize: CGRect, pixelBuffer: CVPixelBuffer) async throws -> CGRect? {
+  func scanDocument(imageBuffer: CVImageBuffer, with previewSize: CGRect) async throws -> CGRect? {
     return try await withCheckedThrowingContinuation { [weak self] continuation in
       guard let self else { continuation.resume(returning: nil); return }
       let request = VNDetectRectanglesRequest { (request: VNRequest, error: Error?) in
@@ -20,13 +20,11 @@ actor DocumentScanner: Sendable {
         }
       }
       
-      request.minimumAspectRatio = 0.3
-      request.maximumAspectRatio = 0.9
-      request.minimumSize = 0.3
-      request.maximumObservations = 1
+      request.minimumAspectRatio = 0.2
+      request.maximumAspectRatio = 1.0
       request.minimumConfidence = 0.8
       
-      let handler = VNImageRequestHandler(cvPixelBuffer: pixelBuffer, options: [:])
+      let handler = VNImageRequestHandler(cvPixelBuffer: imageBuffer, options: [:])
       do {
         try handler.perform([request])
       } catch {

--- a/Projects/Feature/Ledger/Sources/Scene/Ledger/Creaters/Scan/Model/DocumentScanner.swift
+++ b/Projects/Feature/Ledger/Sources/Scene/Ledger/Creaters/Scan/Model/DocumentScanner.swift
@@ -15,7 +15,7 @@ actor DocumentScanner: Sendable {
         
         Task {
           await self.updateRecentScanResult(rectangleObservation)
-          let rect = await self.transformBoundingBox(rectangleObservation, to: previewSize)
+          let rect = await self.transformVisionToIOS(rectangleObservation, to: previewSize)
           continuation.resume(returning: rect)
         }
       }
@@ -55,11 +55,12 @@ actor DocumentScanner: Sendable {
     return context.createCGImage(ciImage, from: ciImage.extent)
   }
   
-  private func transformBoundingBox(_ rectangleObservation: VNRectangleObservation, to previewSize: CGRect) -> CGRect {
-    let transform = CGAffineTransform(scaleX: 1, y: -1).translatedBy(x: 0, y: -previewSize.height)
-    let scale = CGAffineTransform.identity.scaledBy(x: previewSize.width, y: previewSize.height)
-
-    return rectangleObservation.boundingBox.applying(scale).applying(transform)
+  private func transformVisionToIOS(_ rectangleObservation: VNRectangleObservation, to previewSize: CGRect) -> CGRect {
+    let visionRect = rectangleObservation.boundingBox
+    return CGRect(
+      origin: CGPoint(x: CGFloat(visionRect.minX * previewSize.width), y: CGFloat((1 - visionRect.maxY) * previewSize.height)),
+      size: CGSize(width: visionRect.width * previewSize.width, height: visionRect.height * previewSize.height)
+    )
   }
   
   private func updateRecentScanResult(_ rectangleObservation: VNRectangleObservation) {

--- a/Projects/Feature/Ledger/Sources/Scene/Ledger/Creaters/Scan/Model/DocumentScanner.swift
+++ b/Projects/Feature/Ledger/Sources/Scene/Ledger/Creaters/Scan/Model/DocumentScanner.swift
@@ -74,3 +74,5 @@ private extension CGPoint {
   }
 }
 
+extension CVImageBuffer: @unchecked @retroactive Sendable {}
+

--- a/Projects/Feature/Ledger/Sources/Scene/Ledger/Creaters/Scan/ScanCreater/CreateOCRLedgerReactor.swift
+++ b/Projects/Feature/Ledger/Sources/Scene/Ledger/Creaters/Scan/ScanCreater/CreateOCRLedgerReactor.swift
@@ -14,7 +14,7 @@ final class CreateOCRLedgerReactor: Reactor {
   }
   
   enum Mutation {
-    case setImageData(Data?)
+    case setTake(Bool)
     case setLoading(Bool)
     case setError(MoneyMongError)
     case setDestination(State.Destination)
@@ -22,7 +22,7 @@ final class CreateOCRLedgerReactor: Reactor {
   
   struct State {
     let agencyId: Int
-    @Pulse var imageData: Data?
+    @Pulse var isTook: Bool = false
     @Pulse var isLoading: Bool = false
     @Pulse var error: MoneyMongError?
     @Pulse var destination: Destination?
@@ -44,17 +44,17 @@ final class CreateOCRLedgerReactor: Reactor {
   
   func mutate(action: Action) -> Observable<Mutation> {
     switch action {
-    case .onAppear:
-        .just(.setImageData(nil))
     case .receiptShoot(let data):
         .concat([
-          .just(.setImageData(data)),
+          .just(.setTake(true)),
           .just(.setLoading(true)),
           requsetOCR(data),
           .just(.setLoading(false))
         ])
     case let .onError(error):
         .just(.setError(error))
+    case .onAppear:
+        .just(.setTake(false))
     }
   }
   
@@ -62,14 +62,14 @@ final class CreateOCRLedgerReactor: Reactor {
     var newState = state
     newState.error = nil
     switch mutation {
-    case let .setImageData(data):
-      newState.imageData = data
     case let .setLoading(isLoading):
       newState.isLoading = isLoading
     case let .setError(error):
       newState.error = error
     case let .setDestination(destination):
       newState.destination = destination
+    case let .setTake(isTook):
+      newState.isTook = isTook
     }
     return newState
   }

--- a/Projects/Feature/Ledger/Sources/Scene/Ledger/Creaters/Scan/ScanCreater/CreateOCRLedgerVC.swift
+++ b/Projects/Feature/Ledger/Sources/Scene/Ledger/Creaters/Scan/ScanCreater/CreateOCRLedgerVC.swift
@@ -184,16 +184,10 @@ final class CreateOCRLedgerVC: UIViewController, View {
       .bind(to: reactor.action)
       .disposed(by: disposeBag)
     
-    reactor.pulse(\.$imageData)
-      .map { $0 != nil ? UIImage(data: $0!) : nil }
-      .bind(to: captureImageView.rx.image)
-      .disposed(by: disposeBag)
-    
-    reactor.pulse(\.$imageData)
-      .map { $0 == nil }
+    reactor.pulse(\.$isTook)
       .bind(with: self) { owner, value in
-        owner.captureImageView.isHidden = value
-        owner.guideLabel.isHidden = !value
+        owner.captureImageView.isHidden = !value
+        owner.guideLabel.isHidden = value
       }
       .disposed(by: disposeBag)
     
@@ -239,7 +233,9 @@ final class CreateOCRLedgerVC: UIViewController, View {
 }
 
 extension CreateOCRLedgerVC: CameraViewDelegate {
-  func cameraView(_ cameraView: CameraView, didShot result: UIImage) {
+  func cameraView(_ cameraView: CameraView, scanResult result: UIImage, originalImage image: UIImage) {
+    captureImageView.image = image
+    
     guard let imageData = result.jpegData(compressionQuality: 1.0) else { return }
     reactor?.action.onNext(.receiptShoot(imageData))
   }

--- a/Projects/Feature/Ledger/Sources/Scene/Ledger/Creaters/Scan/ScanCreater/CreateOCRLedgerVC.swift
+++ b/Projects/Feature/Ledger/Sources/Scene/Ledger/Creaters/Scan/ScanCreater/CreateOCRLedgerVC.swift
@@ -217,8 +217,8 @@ final class CreateOCRLedgerVC: UIViewController, View {
           .alert(
             title: error.errorTitle,
             subTitle: error.errorDescription,
-            type: .onlyOkButton({ [weak self] in
-              self?.captureImageView.image = nil
+            type: .onlyOkButton({
+              owner.captureImageView.image = nil
             })
           )
         )

--- a/Projects/Feature/Ledger/Sources/Scene/Ledger/Creaters/Scan/ScanCreater/CreateOCRLedgerVC.swift
+++ b/Projects/Feature/Ledger/Sources/Scene/Ledger/Creaters/Scan/ScanCreater/CreateOCRLedgerVC.swift
@@ -238,9 +238,9 @@ final class CreateOCRLedgerVC: UIViewController, View {
   }
 }
 
-extension CreateOCRLedgerVC: AVCapturePhotoCaptureDelegate {
-  func photoOutput(_ output: AVCapturePhotoOutput, didFinishProcessingPhoto photo: AVCapturePhoto, error: Error?) {
-    let imageData = photo.fileDataRepresentation()
+extension CreateOCRLedgerVC: CameraViewDelegate {
+  func cameraView(_ cameraView: CameraView, didShot result: UIImage) {
+    guard let imageData = result.jpegData(compressionQuality: 1.0) else { return }
     reactor?.action.onNext(.receiptShoot(imageData))
   }
 }


### PR DESCRIPTION
## 작업 내용

- [x] 영수증 스캔을 위한 DocumentScanner 구현
- [x] 영수증 스캔 여부를 확인할 수 있도록 MaskLayer 추가

## 리뷰어에게 (필요시)

### scanDocument

```swift
func scanDocument(previewSize: CGRect, pixelBuffer: CVPixelBuffer) async throws -> CGRect?
```

위 메서드를 사용해 `AVCaptureVideoDataOutputSampleBufferDelegate`의 `captureOutput()` 메서드를 통해 얻은 영상 결과물(SampleBuffer)에서 영수증 영역을 스캔한다.

영수증 스캔 성공 시 화면에 표시될 MaskLayer의 `fream` 값을 반환 및 `DocumentScanner`는 스캔 한 영수증의 좌표값을 저장한다.

### editImageWithScanResult

```swift
func editImageWithScanResult(_ imageData: Data) -> CGImage?
```

위 메서드는 가장 최근의 스캔 한 영수증의 좌표값을 통해 촬영된 결과물을 편집 후 반환한다.

## 스크린샷 (필요시)

<img src="https://github.com/user-attachments/assets/a4c137f8-ff4e-4ed6-86a2-9ad9cc0d6a0c" width=300>


