### PR TITLE
[D-0] Coordinator 구조 변경

### DIFF
--- a/Projects/App/Sources/AppCoordinator.swift
+++ b/Projects/App/Sources/AppCoordinator.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-import BaseFeatureInterface
+import BaseFeature
 import MainFeature
 import SignFeature
 import DesignSystem

--- a/Projects/App/Sources/AppCoordinator.swift
+++ b/Projects/App/Sources/AppCoordinator.swift
@@ -6,10 +6,9 @@ import SignFeature
 import DesignSystem
 
 final class AppCoordinator: Coordinator {
-  var navigationController: UINavigationController
+  weak var navigationController: UINavigationController?
   let diContainer: AppDIContainer
   weak var parentCoordinator: Coordinator?
-  var childCoordinators: [Coordinator] = []
   
   init(navigationController: UINavigationController, diContainer: AppDIContainer) {
     self.navigationController = navigationController
@@ -27,13 +26,13 @@ final class AppCoordinator: Coordinator {
     case .login:
       sign(animated: true)
     case .ledger:
-      main(animated: true)
-      let mainCoordinator = childCoordinators.first { $0 is MainTabBarCoordinator }
-      mainCoordinator?.move(to: .ledger)
+      main(animated: true) { mainCoordinator in
+        mainCoordinator.move(to: .ledger)
+      }
     case let .createManualLedger(id):
-      main(animated: true)
-      let mainCoordinator = childCoordinators.first { $0 is MainTabBarCoordinator }
-      mainCoordinator?.move(to: .createManualLedger(id))
+      main(animated: true) { mainCoordinator in
+        mainCoordinator.move(to: .createManualLedger(id))
+      }
     default: break
     }
   }
@@ -50,16 +49,15 @@ extension AppCoordinator {
     )
     signCoordinator.start(animated: true)
     signCoordinator.parentCoordinator = self
-    childCoordinators.append(signCoordinator)
   }
   
-  func main(animated: Bool) {
+  func main(animated: Bool, completion: ((Coordinator) -> Void)? = nil) {
     let mainTabCoordinator = MainTabBarCoordinator(
       navigationController: navigationController,
       diContainer: diContainer.mainDIContainer
     )
     mainTabCoordinator.start(animated: true)
     mainTabCoordinator.parentCoordinator = self
-    childCoordinators.append(mainTabCoordinator)
+    completion?(mainTabCoordinator)
   }
 }

--- a/Projects/Feature/Agency/Sources/Common/AgencyCoordinator.swift
+++ b/Projects/Feature/Agency/Sources/Common/AgencyCoordinator.swift
@@ -6,9 +6,8 @@ import AgencyFeatureInterface
 import CreateAgencyInterface
 
 public final class AgencyCoordinator: Coordinator {
-  public var navigationController: UINavigationController
+  public weak var navigationController: UINavigationController?
   public weak var parentCoordinator: Coordinator?
-  public var childCoordinators: [Coordinator] = []
   
   weak var secondFlowNavigationController: UINavigationController?
   
@@ -26,16 +25,6 @@ public final class AgencyCoordinator: Coordinator {
 
   public func start(animated: Bool) {
     agency(animated: animated)
-  }
-  
-  public func move(to scene: BaseFeature.Scene) {
-    switch scene {
-    case .ledger:
-      parentCoordinator?.move(to: .ledger)
-    case .createManualLedger(let int):
-      parentCoordinator?.move(to: .createManualLedger(int))
-    default: break
-    }
   }
   
   func present(_ scene: Scene, animated: Bool = true) {
@@ -58,7 +47,7 @@ public final class AgencyCoordinator: Coordinator {
   }
   
   func dismiss(animated: Bool = true) {
-    navigationController.topViewController?.dismiss(animated: animated)
+    navigationController?.topViewController?.dismiss(animated: animated)
   }
   
   public func goLedger() {
@@ -73,17 +62,16 @@ extension AgencyCoordinator {
     if let agencyList = vc as? AgencyListVC {
       agencyList.coordinator = self
     }
-    navigationController.viewControllers = [vc]
+    navigationController?.viewControllers = [vc]
   }
   
   private func createAgency(universityType: UniversityType, animated: Bool) {
     let vc = UINavigationController()
     let coordinator = CreateAgencyCoordinator(navigationController: vc)
     coordinator.parentCoordinator = self
-    childCoordinators.append(coordinator)
     coordinator.start(animated: animated, universityType: universityType)
     vc.modalPresentationStyle = .fullScreen
-    navigationController.present(vc, animated: animated)
+    navigationController?.present(vc, animated: animated)
   }
   
   private func joinAgency(id: Int, name: String, animated: Bool) {
@@ -92,7 +80,7 @@ extension AgencyCoordinator {
     
     secondFlowNavigationController = vc as? UINavigationController
     vc.modalPresentationStyle = .fullScreen
-    navigationController.topViewController?.present(vc, animated: animated)
+    navigationController?.topViewController?.present(vc, animated: animated)
   }
   
   private func joinComplete(animated: Bool) {

--- a/Projects/Feature/Agency/Sources/Common/AgencyCoordinator.swift
+++ b/Projects/Feature/Agency/Sources/Common/AgencyCoordinator.swift
@@ -1,10 +1,7 @@
 import UIKit
 
 import DesignSystem
-
 import BaseFeature
-import BaseFeatureInterface
-
 import AgencyFeatureInterface
 import CreateAgencyInterface
 
@@ -31,7 +28,7 @@ public final class AgencyCoordinator: Coordinator {
     agency(animated: animated)
   }
   
-  public func move(to scene: BaseFeatureInterface.Scene) {
+  public func move(to scene: BaseFeature.Scene) {
     switch scene {
     case .ledger:
       parentCoordinator?.move(to: .ledger)

--- a/Projects/Feature/Agency/Sources/Scene/AgencyList/AgencyListVC.swift
+++ b/Projects/Feature/Agency/Sources/Scene/AgencyList/AgencyListVC.swift
@@ -13,7 +13,7 @@ import FlexLayout
 
 public final class AgencyListVC: BaseVC, View {
   public var disposeBag = DisposeBag()
-  weak var coordinator: AgencyCoordinator?
+  var coordinator: AgencyCoordinator?
   
   private let emptyView = EmptyAgencyView()
   

--- a/Projects/Feature/Agency/Sources/Scene/JoinAgency/JoinAgencyVC.swift
+++ b/Projects/Feature/Agency/Sources/Scene/JoinAgency/JoinAgencyVC.swift
@@ -9,7 +9,7 @@ import RxCocoa
 
 final class JoinAgencyVC: BaseVC, ReactorKit.View {
   var disposeBag = DisposeBag()
-  weak var coordinator: AgencyCoordinator?
+  var coordinator: AgencyCoordinator?
   
   private let titleLabel: UILabel = {
     let v = UILabel()

--- a/Projects/Feature/Agency/Sources/Scene/JoinComplete/JoinCompleteVC.swift
+++ b/Projects/Feature/Agency/Sources/Scene/JoinComplete/JoinCompleteVC.swift
@@ -9,7 +9,7 @@ import PinLayout
 
 final class JoinCompleteVC: BaseVC, View {
   var disposeBag = DisposeBag()
-  weak var coordinator: AgencyCoordinator?
+  var coordinator: AgencyCoordinator?
   
   private let iconImageView = UIImageView(image: Images.congrats)
   

--- a/Projects/Feature/Base/Project.swift
+++ b/Projects/Feature/Base/Project.swift
@@ -20,21 +20,10 @@ let project = Project(
             dependencies: [
               .project(target: "DesignSystem", path: .relativeToRoot("Projects/Shared/DesignSystem")),
               .project(target: "Core", path: .relativeToRoot("Projects/Core/Core")),
-              .target(name: "BaseFeatureInterface"),
               .project(target: "AgencyInterface", path: .relativeToRoot("Projects/Domain/Agency")),
               .project(target: "LedgerInterface", path: .relativeToRoot("Projects/Domain/Ledger")),
               .project(target: "UserInterface", path: .relativeToRoot("Projects/Domain/User")),
               .project(target: "AuthInterface", path: .relativeToRoot("Projects/Domain/Auth"))
-            ]
-        ),
-        Target(
-            name: "BaseFeatureInterface",
-            platform: .iOS,
-            product: .framework,
-            bundleId: "com.framework.moneymong.BaseFeatureInterface",
-            deploymentTarget: .iOS(targetVersion: "15.0", devices: .iphone),
-            sources: ["Interface/**"],
-            dependencies: [
             ]
         )
     ]

--- a/Projects/Feature/Base/Sources/Coordinator.swift
+++ b/Projects/Feature/Base/Sources/Coordinator.swift
@@ -11,19 +11,13 @@ public enum Scene {
 }
 
 public protocol Coordinator: AnyObject {
-  var navigationController: UINavigationController { get set }
+  var navigationController: UINavigationController? { get set }
   var parentCoordinator: Coordinator? { get set }
-  var childCoordinators: [Coordinator] { get set }
 
-  func remove() // 자기자신을 부모의 childCoordinators 스택에서 제거
   func move(to scene: Scene) // 특정 화면으로 이동 (부모에게 요청)
 }
 
 public extension Coordinator {
-  func remove() {
-    parentCoordinator?.childCoordinators.removeAll { $0 === self }
-  }
-
   func move(to scene: Scene) {
     switch scene {
     case .main:
@@ -47,6 +41,6 @@ public extension Coordinator {
     }
     
     let vc = SFSafariViewController(url: url)
-    navigationController.topViewController?.present(vc, animated: animated)
+    navigationController?.topViewController?.present(vc, animated: animated)
   }
 }

--- a/Projects/Feature/Base/Sources/Coordinator.swift
+++ b/Projects/Feature/Base/Sources/Coordinator.swift
@@ -25,7 +25,20 @@ public extension Coordinator {
   }
 
   func move(to scene: Scene) {
-    // empty
+    switch scene {
+    case .main:
+      parentCoordinator?.move(to: .main)
+    case .login:
+      parentCoordinator?.move(to: .login)
+    case .ledger:
+      parentCoordinator?.move(to: .ledger)
+    case let .createManualLedger(id):
+      parentCoordinator?.move(to: .createManualLedger(id))
+    case let .createOCRLedger(id):
+      parentCoordinator?.move(to: .createOCRLedger(id))
+    case .agency:
+      parentCoordinator?.move(to: .agency)
+    }
   }
   
   func web(urlString: String, animated: Bool = true) {

--- a/Projects/Feature/CreateAgency/Interface/CreateAgencyCoordinator.swift
+++ b/Projects/Feature/CreateAgency/Interface/CreateAgencyCoordinator.swift
@@ -3,9 +3,8 @@ import UIKit
 import BaseFeature
 
 public final class CreateAgencyCoordinator: Coordinator {
-  public var navigationController: UINavigationController
+  public weak var navigationController: UINavigationController?
   public weak var parentCoordinator: Coordinator?
-  public var childCoordinators: [Coordinator] = []
     
   public init(
     navigationController: UINavigationController
@@ -15,7 +14,7 @@ public final class CreateAgencyCoordinator: Coordinator {
 
   public func start(animated: Bool, universityType: UniversityType) {
     let vc = DIContainer.shared.resolve(type: InputAgencyInfoFactoryInterface.self).make(coordinator: self, universityType: universityType)
-    navigationController.viewControllers = [vc]
+    navigationController?.viewControllers = [vc]
   }
   
   public func move(to scene: Scene) {

--- a/Projects/Feature/CreateAgency/Interface/CreateAgencyCoordinator.swift
+++ b/Projects/Feature/CreateAgency/Interface/CreateAgencyCoordinator.swift
@@ -1,7 +1,6 @@
 import UIKit
 
 import BaseFeature
-import BaseFeatureInterface
 
 public final class CreateAgencyCoordinator: Coordinator {
   public var navigationController: UINavigationController

--- a/Projects/Feature/Ledger/Sources/Common/LedgerCoordinator/ImagePickerPresentable.swift
+++ b/Projects/Feature/Ledger/Sources/Common/LedgerCoordinator/ImagePickerPresentable.swift
@@ -1,7 +1,5 @@
 import UIKit
 
-import BaseFeatureInterface
-
 protocol ImagePickerPresentable {
   func imagePicker(
     target: UIViewController,

--- a/Projects/Feature/Ledger/Sources/Common/LedgerCoordinator/LedgerCoordinator.swift
+++ b/Projects/Feature/Ledger/Sources/Common/LedgerCoordinator/LedgerCoordinator.swift
@@ -7,9 +7,8 @@ import LedgerInterface
 import LedgerFeatureInterface
 
 public final class LedgerCoordinator: Coordinator {
-  public var navigationController: UINavigationController
+  public weak var navigationController: UINavigationController?
   public weak var parentCoordinator: Coordinator?
-  public var childCoordinators: [Coordinator] = []
   var moveTab: ((Int) -> Void)?
   
   enum Scene {
@@ -45,7 +44,7 @@ public final class LedgerCoordinator: Coordinator {
   }
 
   func pop(animated: Bool = true) {
-    navigationController.popViewController(animated: animated)
+    navigationController?.popViewController(animated: animated)
   }
 }
 
@@ -62,7 +61,7 @@ extension LedgerCoordinator {
           
     guard let ledgerMainVC = ledgerFactory.makeLedgerMain(ledgerTab: ledgerTabVC, memberTab: memberTabVC) as? LedgerVC else { return }
     ledgerMainVC.coordinator = self
-    navigationController.viewControllers = [ledgerMainVC]
+    navigationController?.viewControllers = [ledgerMainVC]
   }
   
   private func createManualLedger(
@@ -73,25 +72,23 @@ extension LedgerCoordinator {
     let navigationController = UINavigationController()
     let coordinator = CreateManualLedgerCoordinator(navigationController: navigationController)
     coordinator.parentCoordinator = self
-    parentCoordinator?.childCoordinators.append(coordinator)
     navigationController.modalPresentationStyle = .fullScreen
     coordinator.start(agencyId: agencyId, type: type, animated: false)
-    self.navigationController.present(navigationController, animated: animated)
+    self.navigationController?.present(navigationController, animated: animated)
   }
   
   private func createOCRLedger(agencyId: Int, animated: Bool) {
     let navigationController = UINavigationController()
     let coordinator = CreateOCRLedgerCoordinator(navigationController: navigationController)
     coordinator.parentCoordinator = self
-    parentCoordinator?.childCoordinators.append(coordinator)
     navigationController.modalPresentationStyle = .fullScreen
     coordinator.start(agencyId: agencyId, animated: animated)
-    self.navigationController.present(navigationController, animated: animated)
+    self.navigationController?.present(navigationController, animated: animated)
   }
 
   private func detail(ledgerID: Int, role: Member.Role, animated: Bool = true) {
     guard let vc = DIContainer.shared.resolve(type: LedgerFactoryInterface.self).makeDetail(ledgetID: ledgerID, role: role) as? LedgerDetailVC else { return }
     vc.coordinator = self
-    navigationController.pushViewController(vc, animated: animated)
+    navigationController?.pushViewController(vc, animated: animated)
   }
 }

--- a/Projects/Feature/Ledger/Sources/Common/LedgerCoordinator/LedgerCoordinator.swift
+++ b/Projects/Feature/Ledger/Sources/Common/LedgerCoordinator/LedgerCoordinator.swift
@@ -2,7 +2,6 @@ import UIKit
 
 import DesignSystem
 import BaseFeature
-import BaseFeatureInterface
 import AgencyInterface
 import LedgerInterface
 import LedgerFeatureInterface

--- a/Projects/Feature/Ledger/Sources/Scene/Detail/LedgerDetailVC.swift
+++ b/Projects/Feature/Ledger/Sources/Scene/Detail/LedgerDetailVC.swift
@@ -13,7 +13,7 @@ final class LedgerDetailVC: BaseVC, View, ImagePickerPresentable {
 
   public var disposeBag = DisposeBag()
 
-  weak var coordinator: LedgerCoordinator?
+  var coordinator: LedgerCoordinator?
 
   private let contentsView: LedgerContentsView
 

--- a/Projects/Feature/Ledger/Sources/Scene/Ledger/Creaters/Manual/CreateManualLedgerCoordinator.swift
+++ b/Projects/Feature/Ledger/Sources/Scene/Ledger/Creaters/Manual/CreateManualLedgerCoordinator.swift
@@ -1,7 +1,6 @@
 import UIKit
 
 import BaseFeature
-import BaseFeatureInterface
 import DesignSystem
 import LedgerFeatureInterface
 

--- a/Projects/Feature/Ledger/Sources/Scene/Ledger/Creaters/Manual/CreateManualLedgerCoordinator.swift
+++ b/Projects/Feature/Ledger/Sources/Scene/Ledger/Creaters/Manual/CreateManualLedgerCoordinator.swift
@@ -5,9 +5,8 @@ import DesignSystem
 import LedgerFeatureInterface
 
 final class CreateManualLedgerCoordinator: Coordinator {
-  unowned var navigationController: UINavigationController
+  weak var navigationController: UINavigationController?
   weak var parentCoordinator: Coordinator?
-  var childCoordinators: [Coordinator] = []
   
   enum Scene {
     case imagePicker(delegate: UIImagePickerControllerDelegate & UINavigationControllerDelegate)
@@ -21,6 +20,6 @@ final class CreateManualLedgerCoordinator: Coordinator {
   func start(agencyId: Int, type: ManualPresentType, animated: Bool) {
     guard let vc = DIContainer.shared.resolve(type: LedgerFactoryInterface.self).makeCreateManual(agencyId: agencyId, type: type) as? CreateManualLedgerVC else { return }
     vc.coordinator = self
-    navigationController.pushViewController(vc, animated: animated)
+    navigationController?.pushViewController(vc, animated: animated)
   }
 }

--- a/Projects/Feature/Ledger/Sources/Scene/Ledger/Creaters/Manual/ManualCreater/CreateManualLedgerVC.swift
+++ b/Projects/Feature/Ledger/Sources/Scene/Ledger/Creaters/Manual/ManualCreater/CreateManualLedgerVC.swift
@@ -11,8 +11,6 @@ import RxDataSources
 import PinLayout
 import FlexLayout
 
-// TODO: 각 텍스트 필드에 조건 넣어줘야함
-
 final class CreateManualLedgerVC: BaseVC, View, ImagePickerPresentable {  
   var coordinator: CreateManualLedgerCoordinator?
   private struct ViewSize {
@@ -455,7 +453,7 @@ final class CreateManualLedgerVC: BaseVC, View, ImagePickerPresentable {
     reactor.pulse(\.$selectedSection)
       .compactMap { $0 }
       .bind(with: self) { owner, _ in
-        owner.imagePicker(target: self, animated: true, delegate: owner)
+        owner.imagePicker(target: owner, animated: true, delegate: owner)
       }
       .disposed(by: disposeBag)
     

--- a/Projects/Feature/Ledger/Sources/Scene/Ledger/Creaters/Manual/ManualCreater/CreateManualLedgerVC.swift
+++ b/Projects/Feature/Ledger/Sources/Scene/Ledger/Creaters/Manual/ManualCreater/CreateManualLedgerVC.swift
@@ -13,8 +13,8 @@ import FlexLayout
 
 // TODO: 각 텍스트 필드에 조건 넣어줘야함
 
-final class CreateManualLedgerVC: BaseVC, View, ImagePickerPresentable {
-  weak var coordinator: CreateManualLedgerCoordinator?
+final class CreateManualLedgerVC: BaseVC, View, ImagePickerPresentable {  
+  var coordinator: CreateManualLedgerCoordinator?
   private struct ViewSize {
     static var cell: CGSize {
       let width = UIScreen.main.bounds.width * 0.28
@@ -165,10 +165,6 @@ final class CreateManualLedgerVC: BaseVC, View, ImagePickerPresentable {
     MMTextView(charactorLimitCount: 300, title: "메모")
       .setPlaceholder(to: "메모할 내용을 입력하세요")
   }()
-  
-  deinit {
-    coordinator?.remove()
-  }
 
   override func viewDidLayoutSubviews() {
     super.viewDidLayoutSubviews()

--- a/Projects/Feature/Ledger/Sources/Scene/Ledger/Creaters/Scan/CreateOCRLedgerCoordinator.swift
+++ b/Projects/Feature/Ledger/Sources/Scene/Ledger/Creaters/Scan/CreateOCRLedgerCoordinator.swift
@@ -7,9 +7,8 @@ import LedgerInterface
 import LedgerFeatureInterface
 
 final class CreateOCRLedgerCoordinator: Coordinator {
-  unowned var navigationController: UINavigationController
+  weak var navigationController: UINavigationController?
   weak var parentCoordinator: Coordinator?
-  var childCoordinators: [Coordinator] = []
   
   enum Scene {
     case alert(title: String, subTitle: String?, type: MMAlerts.`Type`)
@@ -25,7 +24,7 @@ final class CreateOCRLedgerCoordinator: Coordinator {
   func start(agencyId: Int, animated: Bool) {
     guard let vc = DIContainer.shared.resolve(type: LedgerFactoryInterface.self).makeOCR(agencyId: agencyId) as? CreateOCRLedgerVC else { return }
     vc.coordinator = self
-    navigationController.viewControllers = [vc]
+    navigationController?.viewControllers = [vc]
   }
   
   @MainActor func present(_ scene: Scene, animated: Bool = true) {
@@ -50,7 +49,7 @@ extension CreateOCRLedgerCoordinator {
   private func scanResult(agencyId: Int, model: OCRResult, imageData: Data, animated: Bool = true) {
     guard let vc = DIContainer.shared.resolve(type: LedgerFactoryInterface.self).makeOCRResult(agencyId: agencyId, model: model, imageData: imageData) as? OCRResultVC else { return }
     vc.coordinator = self
-    navigationController.pushViewController(vc, animated: animated)
+    navigationController?.pushViewController(vc, animated: animated)
   }
   
   private func createManualLedger(
@@ -59,6 +58,6 @@ extension CreateOCRLedgerCoordinator {
     animated: Bool
   ) {
     let vc = DIContainer.shared.resolve(type: LedgerFactoryInterface.self).makeCreateManual(agencyId: agencyId, type: type)
-    navigationController.pushViewController(vc, animated: animated)
+    navigationController?.pushViewController(vc, animated: animated)
   }
 }

--- a/Projects/Feature/Ledger/Sources/Scene/Ledger/Creaters/Scan/CreateOCRLedgerCoordinator.swift
+++ b/Projects/Feature/Ledger/Sources/Scene/Ledger/Creaters/Scan/CreateOCRLedgerCoordinator.swift
@@ -1,7 +1,6 @@
 import UIKit
 
 import BaseFeature
-import BaseFeatureInterface
 import DesignSystem
 import Core
 import LedgerInterface

--- a/Projects/Feature/Ledger/Sources/Scene/Ledger/Creaters/Scan/ScanCreater/CreateOCRLedgerVC.swift
+++ b/Projects/Feature/Ledger/Sources/Scene/Ledger/Creaters/Scan/ScanCreater/CreateOCRLedgerVC.swift
@@ -11,7 +11,7 @@ import ReactorKit
 final class CreateOCRLedgerVC: UIViewController, View {
   var disposeBag = DisposeBag()
   
-  weak var coordinator: CreateOCRLedgerCoordinator?
+  var coordinator: CreateOCRLedgerCoordinator?
   
   private let deviceHeight = UIScreen.main.bounds.height
   
@@ -78,10 +78,6 @@ final class CreateOCRLedgerVC: UIViewController, View {
   }()
   
   private let indicator = MMIndicator()
-  
-  deinit {
-    coordinator?.remove()
-  }
   
   override func viewDidLoad() {
     super.viewDidLoad()

--- a/Projects/Feature/Ledger/Sources/Scene/Ledger/Creaters/Scan/ScanResult/OCRResultVC.swift
+++ b/Projects/Feature/Ledger/Sources/Scene/Ledger/Creaters/Scan/ScanResult/OCRResultVC.swift
@@ -9,7 +9,7 @@ import FlexLayout
 
 final class OCRResultVC: BaseVC, View {
   var disposeBag = DisposeBag()
-  weak var coordinator: CreateOCRLedgerCoordinator?
+  var coordinator: CreateOCRLedgerCoordinator?
   
   private let receiptImageView: UIImageView = {
     let v = UIImageView()

--- a/Projects/Feature/Ledger/Sources/Scene/Ledger/LedgerVC.swift
+++ b/Projects/Feature/Ledger/Sources/Scene/Ledger/LedgerVC.swift
@@ -11,7 +11,7 @@ import FlexLayout
 
 public final class LedgerVC: BaseVC, View {
   public var disposeBag = DisposeBag()
-  weak var coordinator: LedgerCoordinator?
+  var coordinator: LedgerCoordinator?
   
   private let emptyView: LedgerEmptyView = {
     let v = LedgerEmptyView()

--- a/Projects/Feature/Ledger/Sources/Scene/Ledger/TabItems/Ledger/LedgerTabVC.swift
+++ b/Projects/Feature/Ledger/Sources/Scene/Ledger/TabItems/Ledger/LedgerTabVC.swift
@@ -15,7 +15,7 @@ import FlexLayout
 final class LedgerTabVC: BaseVC, View {
   var disposeBag = DisposeBag()
   private var cancellableBag = Set<AnyCancellable>()
-  weak var coordinator: LedgerCoordinator?
+  var coordinator: LedgerCoordinator?
 
   private let floatingButton = FloatingButton()
   private let amountGuideLabel: UILabel = {

--- a/Projects/Feature/Ledger/Sources/Scene/Ledger/TabItems/Member/MemberList/MemberTabVC.swift
+++ b/Projects/Feature/Ledger/Sources/Scene/Ledger/TabItems/Member/MemberList/MemberTabVC.swift
@@ -10,7 +10,7 @@ import ReactorKit
 
 final class MemberTabVC: BaseVC, View {
   var disposeBag = DisposeBag()
-  weak var coordinator: LedgerCoordinator?
+  var coordinator: LedgerCoordinator?
   
   private let profileHeaderLabel: UILabel = {
     let v = UILabel()

--- a/Projects/Feature/Main/Sources/MainDIContainer.swift
+++ b/Projects/Feature/Main/Sources/MainDIContainer.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 import AgencyFeature
-import BaseFeatureInterface
+import BaseFeature
 import Core
 import CreateAgencyInterface
 import LedgerFeature

--- a/Projects/Feature/Main/Sources/MainDIContainer.swift
+++ b/Projects/Feature/Main/Sources/MainDIContainer.swift
@@ -35,7 +35,6 @@ public final class MainDIContainer {
   private func agencyTab(with coordinator: Coordinator) -> UIViewController {
     let vc = UINavigationController()
     let agencyCoordinator = AgencyCoordinator(navigationController: vc)
-    coordinator.childCoordinators.append(agencyCoordinator)
     agencyCoordinator.parentCoordinator = coordinator
     agencyCoordinator.start(animated: false)
     return vc
@@ -44,7 +43,6 @@ public final class MainDIContainer {
   private func ledgerTab(with coordinator: Coordinator) -> UIViewController {
     let vc = UINavigationController()
     let ledgerCoordinator = LedgerCoordinator(navigationController: vc)
-    coordinator.childCoordinators.append(ledgerCoordinator)
     ledgerCoordinator.parentCoordinator = coordinator
     ledgerCoordinator.start(animated: false)
     return vc
@@ -53,7 +51,6 @@ public final class MainDIContainer {
   private func myPageTab(with coordinator: Coordinator) -> UIViewController {
     let vc = UINavigationController()
     let myPageCoordinator = MyPageCoordinator(navigationController: vc)
-    coordinator.childCoordinators.append(myPageCoordinator)
     myPageCoordinator.parentCoordinator = coordinator
     myPageCoordinator.start(animated: false)
     return vc

--- a/Projects/Feature/Main/Sources/MainTabBarCoordinator.swift
+++ b/Projects/Feature/Main/Sources/MainTabBarCoordinator.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-import BaseFeatureInterface
+import BaseFeature
 import LedgerFeature
 
 public final class MainTabBarCoordinator: Coordinator {

--- a/Projects/Feature/Main/Sources/MainTabBarCoordinator.swift
+++ b/Projects/Feature/Main/Sources/MainTabBarCoordinator.swift
@@ -4,14 +4,13 @@ import BaseFeature
 import LedgerFeature
 
 public final class MainTabBarCoordinator: Coordinator {
-  public var navigationController: UINavigationController
+  public weak var navigationController: UINavigationController?
   private let diContainer: MainDIContainer
   public weak var parentCoordinator: Coordinator?
-  public var childCoordinators: [Coordinator] = []
   
   weak var tabBarController: UITabBarController?
 
-  public init(navigationController: UINavigationController, diContainer: MainDIContainer) {
+  public init(navigationController: UINavigationController?, diContainer: MainDIContainer) {
     self.navigationController = navigationController
     self.diContainer = diContainer
   }
@@ -26,7 +25,6 @@ public final class MainTabBarCoordinator: Coordinator {
       debugPrint("move to main")
     case .login: // 로그인으로 이동
       parentCoordinator?.move(to: .login)
-      remove()
     case .ledger: // 장부로 이동
       tabBarController?.selectedIndex = 1
     case let .createManualLedger(agencyID): // 장부 이동 &
@@ -35,22 +33,17 @@ public final class MainTabBarCoordinator: Coordinator {
     case let .createOCRLedger(agencyID):
       tabBarController?.selectedIndex = 1
       NotificationCenter.default.post(name: .presentOCRCreater, object: nil, userInfo: ["id": agencyID])
-    
     case .agency: // 소속으로 이동
       tabBarController?.selectedIndex = 0
     }
-  }
-  
-  deinit {
-    debugPrint(#function)
   }
 }
 
 public extension MainTabBarCoordinator {
   func mainTab(animated: Bool) {
     let vc = diContainer.mainTab(with: self)
-    navigationController.isNavigationBarHidden = true
-    navigationController.viewControllers = [vc]
+    navigationController?.isNavigationBarHidden = true
+    navigationController?.viewControllers = [vc]
     tabBarController = vc
   }
 }

--- a/Projects/Feature/Main/Sources/MainTapViewController.swift
+++ b/Projects/Feature/Main/Sources/MainTapViewController.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-import BaseFeatureInterface
+import BaseFeature
 import Core
 import DesignSystem
 

--- a/Projects/Feature/Main/Sources/MainTapViewController.swift
+++ b/Projects/Feature/Main/Sources/MainTapViewController.swift
@@ -8,7 +8,7 @@ import RxSwift
 
 public final class MainTapViewController: UITabBarController {
   private let disposeBag = DisposeBag()
-  weak var coordinator: Coordinator?
+  var coordinator: Coordinator?
 
   public init() {
     super.init(nibName: nil, bundle: nil)

--- a/Projects/Feature/MyPage/Sources/Common/MyPageCoordinator.swift
+++ b/Projects/Feature/MyPage/Sources/Common/MyPageCoordinator.swift
@@ -6,9 +6,8 @@ import DesignSystem
 import MyPageFeatureInterface
 
 public final class MyPageCoordinator: Coordinator {
-  public var navigationController: UINavigationController
+  public weak var navigationController: UINavigationController?
   public weak var parentCoordinator: Coordinator?
-  public var childCoordinators: [Coordinator] = []
 
   public init(navigationController: UINavigationController) {
     self.navigationController = navigationController
@@ -18,7 +17,6 @@ public final class MyPageCoordinator: Coordinator {
     case alert(title: String, subTitle: String, okAction: () -> Void)
     case web(urlString: String)
     case withrawal
-    case debug
   }
   
   public func start(animated: Bool) {
@@ -33,23 +31,11 @@ public final class MyPageCoordinator: Coordinator {
       web(urlString: urlString)
     case .withrawal:
       withdrawl()
-    case .debug:
-      //debug()
-      break
     }
   }
   
-  func goLogin() {
-    parentCoordinator?.move(to: .login)
-    remove()
-  }
-  
   func pop(animated: Bool = true) {
-    navigationController.popViewController(animated: animated)
-  }
-  
-  deinit {
-    debugPrint(#function)
+    navigationController?.popViewController(animated: animated)
   }
 }
 
@@ -57,13 +43,13 @@ extension MyPageCoordinator {
   private func myPage(animated: Bool) {
     guard let vc = DIContainer.shared.resolve(type: MyPageFactoryInterface.self).makeMyPageVC() as? MyPageVC else { return }
     vc.coordinator = self
-    navigationController.setViewControllers([vc], animated: true)
+    navigationController?.setViewControllers([vc], animated: true)
   }
   
   private func withdrawl(animated: Bool = true) {
     guard let vc = DIContainer.shared.resolve(type: MyPageFactoryInterface.self).makeWithdrawalVC() as? WithdrawalVC else { return }
     vc.coordinator = self
-    navigationController.pushViewController(vc, animated: animated)
+    navigationController?.pushViewController(vc, animated: animated)
   }
   
   private func alert(title: String, subTitle: String, okAction: @escaping () -> Void) {

--- a/Projects/Feature/MyPage/Sources/Common/MyPageCoordinator.swift
+++ b/Projects/Feature/MyPage/Sources/Common/MyPageCoordinator.swift
@@ -2,7 +2,6 @@ import UIKit
 import SwiftUI
 
 import BaseFeature
-import BaseFeatureInterface
 import DesignSystem
 import MyPageFeatureInterface
 

--- a/Projects/Feature/MyPage/Sources/Scene/MyPage/MyPageVC.swift
+++ b/Projects/Feature/MyPage/Sources/Scene/MyPage/MyPageVC.swift
@@ -12,7 +12,7 @@ import FlexLayout
 
 public final class MyPageVC: BaseVC, ReactorKit.View {
   public var disposeBag = DisposeBag()
-  weak var coordinator: MyPageCoordinator?
+  var coordinator: MyPageCoordinator?
   
   private let tableView: UITableView = {
     let v = UITableView(frame: .zero, style: .insetGrouped)
@@ -99,10 +99,6 @@ public final class MyPageVC: BaseVC, ReactorKit.View {
           subTitle: "로그인한 계정이 로그아웃됩니다",
           okAction: { reactor.action.onNext(.logout) })
         )
-      case .setting(.versionInfo):
-        #if DEBUG
-        owner.coordinator?.present(.debug)
-        #endif
       default: break
       }
     }
@@ -139,7 +135,7 @@ public final class MyPageVC: BaseVC, ReactorKit.View {
       .bind(with: self) { owner, destination in
         switch destination {
         case .login:
-          owner.coordinator?.goLogin()
+          owner.coordinator?.move(to: .login)
         }
       }
       .disposed(by: disposeBag)

--- a/Projects/Feature/MyPage/Sources/Scene/Withdrawal/WithdrawalVC.swift
+++ b/Projects/Feature/MyPage/Sources/Scene/Withdrawal/WithdrawalVC.swift
@@ -11,7 +11,7 @@ import FlexLayout
 
 public final class WithdrawalVC: BaseVC, View {
   public var disposeBag = DisposeBag()
-  weak var coordinator: MyPageCoordinator?
+  var coordinator: MyPageCoordinator?
   
   private let titleLabel: UILabel = {
     let v = UILabel()
@@ -128,7 +128,7 @@ public final class WithdrawalVC: BaseVC, View {
       .compactMap { $0 }
       .observe(on: MainScheduler.instance)
       .bind(with: self) { owner, value in
-        owner.coordinator?.goLogin()
+        owner.coordinator?.move(to: .login)
       }
       .disposed(by: disposeBag)
   }

--- a/Projects/Feature/Sign/Sources/Scene/Common/SignCoordinator.swift
+++ b/Projects/Feature/Sign/Sources/Scene/Common/SignCoordinator.swift
@@ -1,7 +1,6 @@
 import UIKit
 
 import BaseFeature
-import BaseFeatureInterface
 import CreateAgencyInterface
 import DesignSystem
 import SignFeatureInterface

--- a/Projects/Feature/Sign/Sources/Scene/Common/SignCoordinator.swift
+++ b/Projects/Feature/Sign/Sources/Scene/Common/SignCoordinator.swift
@@ -6,35 +6,15 @@ import DesignSystem
 import SignFeatureInterface
 
 public final class SignCoordinator: Coordinator {
-  public var navigationController: UINavigationController
+  public weak var navigationController: UINavigationController?
   public weak var parentCoordinator: Coordinator?
-  public var childCoordinators: [Coordinator] = []
   
-  public init(navigationController: UINavigationController) {
+  public init(navigationController: UINavigationController?) {
     self.navigationController = navigationController
   }
 
   public func start(animated: Bool) {
     splash()
-  }
-  
-  public func move(to scene: Scene) {
-    switch scene {
-    case .main:
-      parentCoordinator?.move(to: .main)
-      remove()
-    case .ledger:
-      parentCoordinator?.move(to: .ledger)
-      remove()
-    case .createManualLedger(let id):
-      parentCoordinator?.move(to: .createManualLedger(id))
-      remove()
-    default: break
-    }
-  }
-  
-  deinit {
-    debugPrint(#function)
   }
 }
 
@@ -42,39 +22,33 @@ public extension SignCoordinator {
   func splash(animated: Bool = false) {
     guard let vc = DIContainer.shared.resolve(type: SignFactoryInterface.self).makeSplash() as? SplashVC else { return }
     vc.coordinator = self
-    navigationController.isNavigationBarHidden = false
-    navigationController.viewControllers = [vc]
+    navigationController?.isNavigationBarHidden = false
+    navigationController?.viewControllers = [vc]
   }
 
   func login(animated: Bool = false) {
     guard let vc = DIContainer.shared.resolve(type: SignFactoryInterface.self).makeLogin() as? LoginVC else { return }
     vc.coordinator = self
-    self.navigationController.pushViewController(vc, animated: animated)
-  }
-
-  func main() {
-    parentCoordinator?.move(to: .main)
-    remove()
+    self.navigationController?.pushViewController(vc, animated: animated)
   }
 
   func createAgency(animated: Bool = true) {
     let vc = UINavigationController()
     let coordinator = CreateAgencyCoordinator(navigationController: vc)
     coordinator.parentCoordinator = self
-    childCoordinators.append(coordinator)
     coordinator.start(animated: true, universityType: .unknown)
     vc.modalPresentationStyle = .fullScreen
-    navigationController.present(vc, animated: animated)
+    navigationController?.present(vc, animated: animated)
   }
 
   func congratulations(animated: Bool = true) {
     guard let vc = DIContainer.shared.resolve(type: SignFactoryInterface.self).makeCongratulation() as? CongratulationsVC else { return }
     vc.coordinator = self
-    navigationController.pushViewController(vc, animated: animated)
+    navigationController?.pushViewController(vc, animated: animated)
   }
 
   func pop(animated: Bool = true) {
-    navigationController.popViewController(animated: animated)
+    navigationController?.popViewController(animated: animated)
   }
 
   func alert(title: String, okAction: (() -> Void)? = nil) {

--- a/Projects/Feature/Sign/Sources/Scene/Congratulations/CongratulationsVC.swift
+++ b/Projects/Feature/Sign/Sources/Scene/Congratulations/CongratulationsVC.swift
@@ -9,7 +9,7 @@ import ReactorKit
 
 final class CongratulationsVC: BaseVC, View {
 
-  weak var coordinator: SignCoordinator?
+  var coordinator: SignCoordinator?
   var disposeBag = DisposeBag()
 
   private let imageView: UIImageView = {
@@ -83,7 +83,7 @@ final class CongratulationsVC: BaseVC, View {
       .bind(with: self) { owner, destination in
         switch destination {
         case .main:
-          owner.coordinator?.main()
+          owner.coordinator?.move(to: .main)
         }
       }
       .disposed(by: disposeBag)

--- a/Projects/Feature/Sign/Sources/Scene/Login/LoginVC.swift
+++ b/Projects/Feature/Sign/Sources/Scene/Login/LoginVC.swift
@@ -6,7 +6,7 @@ import ReactorKit
 
 final class LoginVC: BaseVC, View {
 
-  weak var coordinator: SignCoordinator?
+  var coordinator: SignCoordinator?
   var disposeBag = DisposeBag()
 
   private let imageView: UIImageView = {
@@ -111,7 +111,7 @@ final class LoginVC: BaseVC, View {
       .bind(with: self) { owner, destination in
         switch destination {
         case .main:
-          owner.coordinator?.main()
+          owner.coordinator?.move(to: .main)
         case .signUp:
           owner.coordinator?.createAgency()
         }

--- a/Projects/Feature/Sign/Sources/Scene/Splash/SplashVC.swift
+++ b/Projects/Feature/Sign/Sources/Scene/Splash/SplashVC.swift
@@ -6,7 +6,7 @@ import ReactorKit
 
 final class SplashVC: BaseVC, View {
 
-  weak var coordinator: SignCoordinator?
+  var coordinator: SignCoordinator?
   var disposeBag = DisposeBag()
 
   private let logoImageView: UIImageView = {
@@ -44,9 +44,9 @@ final class SplashVC: BaseVC, View {
       .bind(with: self) { owner, destination in
         switch destination {
         case .login:
-          owner.coordinator?.login()
+          owner.coordinator?.move(to: .login)
         case .main:
-          owner.coordinator?.main()
+          owner.coordinator?.move(to: .main)
         }
       }
       .disposed(by: disposeBag)


### PR DESCRIPTION
## 작업 내용

- [x] childCoordinators 삭제
- [x] vc -> coordinator 강한참조로 변경
- [x] coordinator -> navigationCoordinator 약한참조로 변경
- [x] coordinator BaseFeature로 모듈 위치 변경

## 리뷰어에게 (필요시)

### Coordinator 구조 변경

기존 parent - child 구조의 경우,

<img width=50% src="https://github.com/user-attachments/assets/a6d813b1-38a1-4111-aa6b-340c50bad635">

`coordinator`를 참조하는 `VC`가 모두 메모리에서 해제되더라도 `parentCoordinator`의 `childCoordinators`로 인해 `coordinator`는 해제되지 않는다. 때문에 올바른 시점에 `remove()` 메서드를 호출시켜주지 않으면, 메모리 누수가 발생한다. 즉, 개발자가 직접 `coordinator`를 메모리에세 해제 시켜야한다.

Self-deallocated Coordinator 구조의 경우

<img width=50% src="https://github.com/user-attachments/assets/fe26c40f-5c6b-4c05-8712-d9b12675c3ab">

`childCoordinators` 배열로 `coodinator`의 RC를 관리하는 것이 아닌 `coodinator`를 사용하는 `VC`가 `coodinator`의 RC를 관리한다. 즉, `coodinator`를 의존하는 `VC`가 모두 메모리에세 해제되면 자동으로 `coodinator`도 함께 메모리에서 해제된다. 

단, `coordinator`가 `navigationController`를 강한참조할 경우 순환 참조가 발생하기 때문에 약한참조로 의존하여 순환 참조가 발생하지 않게 해야한다.

## 스크린샷 (필요시)
