### PR TITLE
2.0.0 QA 2차 반영

### DIFF
--- a/Projects/App/Sources/SceneDelegate.swift
+++ b/Projects/App/Sources/SceneDelegate.swift
@@ -72,6 +72,7 @@ extension SceneDelegate {
     let networkManager = NetworkManager()
     let ledgerService = LedgerService()
     let contentFormatter = ContentFormatter()
+    let memoryCache = MemoryCache()
     
     networkManager.tokenIntercepter = TokenRequestIntercepter(
       localStorage: localStorage,
@@ -85,45 +86,45 @@ extension SceneDelegate {
     
     // MARK: - User UseCase Dependency
     DIContainer.shared.register(type: GetMyInfoUseCaseInterface.self) {
-      let userRepo = UserRepository(networkManager: networkManager, localStorage: localStorage, memoryCache: MemoryCache.shared)
+      let userRepo = UserRepository(networkManager: networkManager, localStorage: localStorage, memoryCache: memoryCache)
       return GetMyInfoUseCase(userRepo: userRepo)
     }
     
     DIContainer.shared.register(type: GetSelectedAgencyUseCaseInterface.self) {
-      let userRepo = UserRepository(networkManager: networkManager, localStorage: localStorage, memoryCache: MemoryCache.shared)
+      let userRepo = UserRepository(networkManager: networkManager, localStorage: localStorage, memoryCache: memoryCache)
       return GetSelectedAgencyUseCase(userRepo: userRepo)
     }
     
     DIContainer.shared.register(type: UpdateSelectedAgencyUseCaseInterface.self) {
-      let userRepo = UserRepository(networkManager: networkManager, localStorage: localStorage, memoryCache: MemoryCache.shared)
+      let userRepo = UserRepository(networkManager: networkManager, localStorage: localStorage, memoryCache: memoryCache)
       return UpdateSelectedAgencyUseCase(userRepo: userRepo)
     }
     
     DIContainer.shared.register(type: GetUserIDUseCaseInterface.self) {
-      let userRepo = UserRepository(networkManager: networkManager, localStorage: localStorage, memoryCache: MemoryCache.shared)
+      let userRepo = UserRepository(networkManager: networkManager, localStorage: localStorage, memoryCache: memoryCache)
       return GetUserIDUseCase(userRepo: userRepo)
     }
     
     // MARK: - Auth UseCase Dependency
     DIContainer.shared.register(type: AutoSignUseCaseInterface.self) {
-      let userRepo = UserRepository(networkManager: networkManager, localStorage: localStorage, memoryCache: MemoryCache.shared)
+      let userRepo = UserRepository(networkManager: networkManager, localStorage: localStorage, memoryCache: memoryCache)
       let versionRepo = VersionRepository(networkManager: networkManager)
       return AutoSignUseCase(userRepo: userRepo, versionRepo: versionRepo)
     }
     
     DIContainer.shared.register(type: DeleteUserUseCaseInterface.self) {
-      let userRepo = UserRepository(networkManager: networkManager, localStorage: localStorage, memoryCache: MemoryCache.shared)
+      let userRepo = UserRepository(networkManager: networkManager, localStorage: localStorage, memoryCache: memoryCache)
       return DeleteUserUseCase(userRepo: userRepo)
     }
     
     DIContainer.shared.register(type: LogoutUseCaseInterface.self) {
-      let userRepo = UserRepository(networkManager: networkManager, localStorage: localStorage, memoryCache: MemoryCache.shared)
+      let userRepo = UserRepository(networkManager: networkManager, localStorage: localStorage, memoryCache: memoryCache)
       return LogoutUseCase(userRepo: userRepo)
     }
     
     DIContainer.shared.register(type: SignUpUseCaseInterface.self) {
       let signRepo = SignRepository(networkManager: networkManager, localStorage: localStorage)
-      let userRepo = UserRepository(networkManager: networkManager, localStorage: localStorage, memoryCache: MemoryCache.shared)
+      let userRepo = UserRepository(networkManager: networkManager, localStorage: localStorage, memoryCache: memoryCache)
       return SignUpUseCase(signRepo: signRepo, userRepo: userRepo)
     }
     
@@ -134,49 +135,49 @@ extension SceneDelegate {
     
     // MARK: - Agency UseCase Dependency
     DIContainer.shared.register(type: ChangeMemberRoleUseCaseInterface.self) {
-      let agencyRepo = AgencyRepository(networkManager: networkManager, localStorage: localStorage)
+      let agencyRepo = AgencyRepository(networkManager: networkManager, localStorage: localStorage, memoryCache: memoryCache)
       return ChangeMemberRoleUseCase(repo: agencyRepo)
     }
 
     DIContainer.shared.register(type: ConfirmCertificateCodeUseCaseInterface.self) {
-      let agencyRepo = AgencyRepository(networkManager: networkManager, localStorage: localStorage)
-      let userRepo = UserRepository(networkManager: networkManager, localStorage: localStorage, memoryCache: MemoryCache.shared)
+      let agencyRepo = AgencyRepository(networkManager: networkManager, localStorage: localStorage, memoryCache: memoryCache)
+      let userRepo = UserRepository(networkManager: networkManager, localStorage: localStorage, memoryCache: memoryCache)
       return ConfirmCertificateCodeUseCase(agencyRepo: agencyRepo, userRepo: userRepo)
     }
 
     DIContainer.shared.register(type: CreateAgencyUseCaseInterface.self) {
-      let agencyRepo = AgencyRepository(networkManager: networkManager, localStorage: localStorage)
+      let agencyRepo = AgencyRepository(networkManager: networkManager, localStorage: localStorage, memoryCache: memoryCache)
       return CreateAgencyUseCase(repo: agencyRepo)
     }
 
     DIContainer.shared.register(type: DeleteAgencyUseCaseInterface.self) {
-      let agencyRepo = AgencyRepository(networkManager: networkManager, localStorage: localStorage)
-      let userRepo = UserRepository(networkManager: networkManager, localStorage: localStorage, memoryCache: MemoryCache.shared)
+      let agencyRepo = AgencyRepository(networkManager: networkManager, localStorage: localStorage, memoryCache: memoryCache)
+      let userRepo = UserRepository(networkManager: networkManager, localStorage: localStorage, memoryCache: memoryCache)
       return DeleteAgencyUseCase(agencyRepo: agencyRepo, userRepo: userRepo, widgetRefreshController: widgetRefreshController)
     }
 
     DIContainer.shared.register(type: GetInvitationCodeUseCaseInterface.self) {
-      let agencyRepo = AgencyRepository(networkManager: networkManager, localStorage: localStorage)
+      let agencyRepo = AgencyRepository(networkManager: networkManager, localStorage: localStorage, memoryCache: memoryCache)
       return GetInvitationCodeUseCase(repo: agencyRepo)
     }
 
     DIContainer.shared.register(type: GetMemberListUseCaseInterface.self) {
-      let agencyRepo = AgencyRepository(networkManager: networkManager, localStorage: localStorage)
+      let agencyRepo = AgencyRepository(networkManager: networkManager, localStorage: localStorage, memoryCache: memoryCache)
       return GetMemberListUseCase(repo: agencyRepo)
     }
 
     DIContainer.shared.register(type: GetMyAgencyUseCaseInterface.self) {
-      let agencyRepo = AgencyRepository(networkManager: networkManager, localStorage: localStorage)
+      let agencyRepo = AgencyRepository(networkManager: networkManager, localStorage: localStorage, memoryCache: memoryCache)
       return GetMyAgencyUseCase(repo: agencyRepo)
     }
 
     DIContainer.shared.register(type: KickoutMemberUseCaseInterface.self) {
-      let agencyRepo = AgencyRepository(networkManager: networkManager, localStorage: localStorage)
+      let agencyRepo = AgencyRepository(networkManager: networkManager, localStorage: localStorage, memoryCache: memoryCache)
       return KickoutMemberUseCase(repo: agencyRepo)
     }
 
     DIContainer.shared.register(type: ReissueCodeUseCaseInterface.self) {
-      let agencyRepo = AgencyRepository(networkManager: networkManager, localStorage: localStorage)
+      let agencyRepo = AgencyRepository(networkManager: networkManager, localStorage: localStorage, memoryCache: memoryCache)
       return ReissueCodeUseCase(repo: agencyRepo)
     }
     
@@ -246,7 +247,7 @@ extension SceneDelegate {
     }
     
     DIContainer.shared.register(type: JoinAgencyCoordinatorInterface.self) {
-      return JoinAgencyCoordinator()
+      return JoinAgencyCoordinator(ledgerService: ledgerService)
     }
     
     DIContainer.shared.register(type: LedgerCoordinatorInterface.self) {

--- a/Projects/Core/MMNetwork/Sources/MemoryCache.swift
+++ b/Projects/Core/MMNetwork/Sources/MemoryCache.swift
@@ -4,9 +4,7 @@ import MMNetworkInterface
 
 public final class MemoryCache: Cacheable {
   private let cache = NSCache<NSString, NSData>()
-  
-  public static let shared = MemoryCache(memoryPercent: 0.05)
-  
+    
   public init(totalCostLimit: Int) {
     cache.totalCostLimit = totalCostLimit
   }

--- a/Projects/Core/Repository/Sources/APIs/AgencyAPI/Repository/AgencyAPI.swift
+++ b/Projects/Core/Repository/Sources/APIs/AgencyAPI/Repository/AgencyAPI.swift
@@ -27,7 +27,7 @@ extension AgencyAPI: TargetType {
     case let .kickout(id, _): return "v1/agencies/\(id)/agency-users/roles/block"
     case .myAgency: return "v1/agencies/me"
     case let .code(id): return "v1/agencies/\(id)/invitation-code"
-    case .certificateCode: return "v1/agencies/invitation-code"
+    case .certificateCode: return "v2/agencies/invitation-code"
     case let .reissueCode(id): return "v1/agencies/\(id)/invitation-code"
     case let .delete(id): return "v1/agencies/\(id)"
     }

--- a/Projects/Core/Repository/Sources/APIs/AgencyAPI/Repository/AgencyRepository.swift
+++ b/Projects/Core/Repository/Sources/APIs/AgencyAPI/Repository/AgencyRepository.swift
@@ -8,15 +8,18 @@ import Utility
 public struct AgencyRepository: AgencyRepositoryInterface {
   private let networkManager: NetworkManagerInterfacae
   private let localStorage: LocalStorageInterface
+  private let memoryCache: Cacheable
 
-  public init(networkManager: NetworkManagerInterfacae, localStorage: LocalStorageInterface) {
+  public init(networkManager: NetworkManagerInterfacae, localStorage: LocalStorageInterface, memoryCache: Cacheable) {
     self.networkManager = networkManager
     self.localStorage = localStorage
+    self.memoryCache = memoryCache
   }
   
   public func create(name: String) async throws -> Int {
     let targetType = AgencyAPI.create(param: .init(name: name, agencyType: "GENERAL"))
     let agencyID = try await networkManager.request(target: targetType, of: AgencyIDResponseDTO.self).id
+    memoryCache.delete(key: "v1/agencies/me")
     FirebaseManager.shared.logEvent(
       event: .createAgency,
       parameters: [
@@ -54,7 +57,7 @@ public struct AgencyRepository: AgencyRepositoryInterface {
   
   public func fetchMyAgency() async throws -> [Agency] {
     let targetType = AgencyAPI.myAgency
-    let dto = try await networkManager.request(target: targetType, of: [AgencyResponseDTO].self)
+    let dto = try await networkManager.request(target: targetType, of: [AgencyResponseDTO].self, cache: memoryCache)
     return dto.toEntity
   }
   
@@ -67,6 +70,7 @@ public struct AgencyRepository: AgencyRepositoryInterface {
   public func certificateCode(code: String) async throws -> CertificationResult {
     let targetType = AgencyAPI.certificateCode(param: .init(invitationCode: code))
     let dto = try await networkManager.request(target: targetType, of: CertificateCodeRequestDTO.self)
+    memoryCache.delete(key: "v1/agencies/me")
     FirebaseManager.shared.logEvent(
       event: .joinAgency,
       parameters: [
@@ -94,5 +98,6 @@ public struct AgencyRepository: AgencyRepositoryInterface {
       ]
     )
     localStorage.deleteCurrentLedgerInfo()
+    memoryCache.delete(key: "v1/agencies/me")
   }
 }

--- a/Projects/Domain/Agency/Interface/ConfirmCertificateCodeUseCaseInterface.swift
+++ b/Projects/Domain/Agency/Interface/ConfirmCertificateCodeUseCaseInterface.swift
@@ -1,6 +1,8 @@
 import Foundation
 
+import BaseDomain
+
 // 소속가입시, 초대코드가 맞는지 확인한다
 public protocol ConfirmCertificateCodeUseCaseInterface {
-  func execute(code: [String]) async throws -> Bool
+  func execute(code: [String]) async throws -> Agency?
 }

--- a/Projects/Domain/Agency/Sources/ConfirmCertificateCodeUseCase.swift
+++ b/Projects/Domain/Agency/Sources/ConfirmCertificateCodeUseCase.swift
@@ -15,13 +15,14 @@ public struct ConfirmCertificateCodeUseCase: ConfirmCertificateCodeUseCaseInterf
     self.userRepo = userRepo
   }
   
-  public func execute(code: [String]) async throws -> Bool {
+  public func execute(code: [String]) async throws -> Agency? {
     let codes = code.compactMap { $0 }.map { String($0) }.joined()
     
     let response = try await agencyRepo.certificateCode(code: codes)
     if response.certified {
       userRepo.updateSelectedAgency(id: response.agencyId)
+      return try await agencyRepo.fetchMyAgency().first { $0.id == response.agencyId }
     }
-    return response.certified
+    return nil
   }
 }

--- a/Projects/Feature/Agency/Sources/Common/AgencyFactory.swift
+++ b/Projects/Feature/Agency/Sources/Common/AgencyFactory.swift
@@ -11,10 +11,10 @@ struct AgencyFactory {
   
   init() { }
   
-  func makeJoinAgency() -> JoinAgencyVC {
+  func makeJoinAgency(ledgerService: LedgerServiceInterface?) -> JoinAgencyVC {
     let vc = JoinAgencyVC()
     vc.reactor = JoinAgencyReactor(
-      confirmCertificateCodeUseCase: DIContainer.shared.resolve(type: ConfirmCertificateCodeUseCaseInterface.self)
+      confirmCertificateCodeUseCase: DIContainer.shared.resolve(type: ConfirmCertificateCodeUseCaseInterface.self), ledgerService: ledgerService
     )
     return vc
   }

--- a/Projects/Feature/Agency/Sources/Common/JoinAgencyCoordinator.swift
+++ b/Projects/Feature/Agency/Sources/Common/JoinAgencyCoordinator.swift
@@ -3,12 +3,17 @@ import UIKit
 import AgencyFeatureInterface
 import BaseFeature
 import DesignSystem
+import LedgerFeatureInterface
 
 public final class JoinAgencyCoordinator: JoinAgencyCoordinatorInterface {
   public weak var navigationController: UINavigationController?
   public weak var parentCoordinator: Coordinator?
   
-  public init() {}
+  private let ledgerService: LedgerServiceInterface?
+  
+  public init(ledgerService: LedgerServiceInterface?) {
+    self.ledgerService = ledgerService
+  }
   
   enum Destination {
     case joinComplete
@@ -45,7 +50,7 @@ public final class JoinAgencyCoordinator: JoinAgencyCoordinatorInterface {
 
 private extension JoinAgencyCoordinator {
   private func joinAgency(animated: Bool) {
-    let vc = AgencyFactory().makeJoinAgency()
+    let vc = AgencyFactory().makeJoinAgency(ledgerService: ledgerService)
     vc.coordinator = self
     navigationController?.pushViewController(vc, animated: animated)
   }

--- a/Projects/Feature/Agency/Sources/Scene/JoinAgency/JoinAgencyReactor.swift
+++ b/Projects/Feature/Agency/Sources/Scene/JoinAgency/JoinAgencyReactor.swift
@@ -3,6 +3,7 @@ import ReactorKit
 import AgencyInterface
 import BaseDomain
 import Utility
+import LedgerFeatureInterface
 
 final class JoinAgencyReactor: Reactor {
   struct State {
@@ -25,18 +26,21 @@ final class JoinAgencyReactor: Reactor {
   
   enum Mutation {
     case setCode(code: String, index: Int)
-    case joinAgencyResponse(Result<Bool, MoneyMongError>)
+    case joinAgencyResponse(Result<Agency?, MoneyMongError>)
   }
   
   let initialState: State
   
   private let confirmCertificateCodeUseCase: ConfirmCertificateCodeUseCaseInterface
-  
+  private let ledgerService: LedgerServiceInterface?
+
   init(
-    confirmCertificateCodeUseCase: ConfirmCertificateCodeUseCaseInterface
+    confirmCertificateCodeUseCase: ConfirmCertificateCodeUseCaseInterface,
+    ledgerService: LedgerServiceInterface?
   ) {
     self.initialState = .init()
     self.confirmCertificateCodeUseCase = confirmCertificateCodeUseCase
+    self.ledgerService = ledgerService
   }
   
   func mutate(action: Action) -> Observable<Mutation> {
@@ -53,7 +57,7 @@ final class JoinAgencyReactor: Reactor {
       return .task {
         return try await confirmCertificateCodeUseCase.execute(code: codes)
       }
-      .map { .joinAgencyResponse(.success($0)) }
+      .map { agency in .joinAgencyResponse(.success(agency)) }
       .catch { return .just(.joinAgencyResponse(.failure($0.toMMError))) }
       
     case .tapRetryButton:
@@ -74,11 +78,10 @@ final class JoinAgencyReactor: Reactor {
     case let .setCode(code, index):
       newState.codes[index] = code
     case let .joinAgencyResponse(.success(value)):
-      switch value {
-      case true:
-        
+      if let agency = value {
+        ledgerService?.agency.updateAgency(agency)
         newState.destination = .joinComplete
-      case false:
+      } else {
         newState.snackBarMessage = "잘못된 초대코드입니다"
       }
       

--- a/Projects/Feature/Ledger/Sources/Scene/Ledger/Sheets/SelectAgency/SelectAgencySheetReactor.swift
+++ b/Projects/Feature/Ledger/Sources/Scene/Ledger/Sheets/SelectAgency/SelectAgencySheetReactor.swift
@@ -58,11 +58,9 @@ final class SelectAgencySheetReactor: Reactor {
     case .onAppear:
       return .concat(
         .just(.setLoading(true)),
-        
         .task { try await getMyAgencyUseCase.execute() }
-        .map { .setAgencies($0) }
-        .catch { return .just(.setError($0.toMMError)) },
-        
+          .map { .setAgencies($0) }
+          .catch { return .just(.setError($0.toMMError)) },
         .just(.setLoading(false))
       )
     case let .tapCell(agency):

--- a/Projects/Feature/Sign/Sources/Scene/Login/LoginReactor.swift
+++ b/Projects/Feature/Sign/Sources/Scene/Login/LoginReactor.swift
@@ -1,5 +1,7 @@
 import AuthInterface
+import AgencyInterface
 import BaseDomain
+import BaseFeature
 
 import ReactorKit
 
@@ -33,13 +35,16 @@ final class LoginReactor: Reactor {
   
   private let signUpUseCase: SignUpUseCaseInterface
   private let getRecentLoginInfoUseCase: GetRecentLoginInfoUseCaseInterface
+  private let getMyAgencyUseCase: GetMyAgencyUseCaseInterface
 
   init(
     signUpUseCase: SignUpUseCaseInterface,
-    getRecentLoginInfoUseCase: GetRecentLoginInfoUseCaseInterface
+    getRecentLoginInfoUseCase: GetRecentLoginInfoUseCaseInterface,
+    getMyAgencyUseCase: GetMyAgencyUseCaseInterface = DIContainer.shared.resolve(type: GetMyAgencyUseCaseInterface.self)
   ) {
     self.signUpUseCase = signUpUseCase
     self.getRecentLoginInfoUseCase = getRecentLoginInfoUseCase
+    self.getMyAgencyUseCase = getMyAgencyUseCase
   }
 
   func mutate(action: Action) -> Observable<Mutation> {
@@ -51,9 +56,10 @@ final class LoginReactor: Reactor {
 
     case .login(let loginType):
       return .task {
-        return try await signUpUseCase.execute(loginType: loginType)
+        _ = try await signUpUseCase.execute(loginType: loginType)
+        return try await !getMyAgencyUseCase.execute().isEmpty
       }
-      .map { .setDestination($0.schoolInfoExist ? .main : .signUp) }
+      .map { .setDestination($0 ? .main : .signUp) }
       .catch { .just(.setErrorMessage($0.localizedDescription)) }
     }
   }


### PR DESCRIPTION
## 작업 내용

- [x] 로그인 시 등록된 소속이 없는 경우 소속 생성 화면으로 이동 되도록 수정
- [x] 초대코드 통한 소속 등록 API 버전 수정 및 UseCase 반환 타입 변경(Bool -> Agency?)
- [x] fetchMyAgency api responce cache 적용

## 메모
- fetchMyAgency api 반복적인 호출로 인해 네트워크 사용량을 최소화하고자 Memory Cache 적용
소속 가입, 탈퇴 시 Cache 초기화되도록 구현
